### PR TITLE
Fix reading the `output` option from the `--reporter-options` argument.

### DIFF
--- a/lib/trx.js
+++ b/lib/trx.js
@@ -59,7 +59,7 @@ function ReporterTrx(runner, options) {
             run.addResult(testToTrx(test, computerName));
         });
 
-        var filename = getFilename(self.reporterOptions);
+        var filename = getFilename(options ? options.reporterOptions : null);
         if (filename) {
             require('fs').writeFileSync(filename, run.toXml());
         } else {


### PR DESCRIPTION
Fix for passing the reporter options into the function that retrieves the output filename.