### PR TITLE
Support Pending (skip) and Timeout outcomes

### DIFF
--- a/lib/test-to-trx.js
+++ b/lib/test-to-trx.js
@@ -13,15 +13,15 @@ module.exports = testToTrx;
 function testToTrx(test, computerName) {
     return {
         test: new UnitTest({
-            name: test.fullTitle,
+            name: test.fullTitle(),
             methodName: '', //??
             methodCodeBase: '', //??
             methodClassName: '', //??
             description: test.title
         }),
         computerName: computerName,
-        outcome: formatOutcome(test.state),
-        duration: formatDuration(test.duration),
+        outcome: formatOutcome(test),
+        duration: formatDuration(test.duration || 0),
         startTime: test.start && test.start.toISOString() || '', //'2010-11-16T08:48:29.9072393-08:00',
         endTime: test.end && test.end.toISOString() || '', //'2010-11-16T08:49:16.9694381-08:00'
         errorMessage: test.err && test.err._message || '',
@@ -47,26 +47,33 @@ function formatDuration(milliseconds) {
 }
 
 /**
- * Transform mocha test state to trx outcome
+ * Transform mocha test result to trx outcome.
  *
- * input     | output
- * ---------------------
+ * Tests may have timed out, resulting in outcome 'Timeout'.
+ * Tests may be pending as indicated by the test itself or their parent suite, resulting in outcome 'Pending'.
+ * When not pending, the Mocha test state is converted as follows:
+ *
+ * State     | TRX outcome
+ * --------------------------
  * 'passed'  | 'Passed'
  * 'failed'  | 'Failed'
  * undefined | 'Inconclusive'
  *
- * @param input
+ * @param test
  * @returns {string}
  */
-function formatOutcome(input) {
-    var output;
-    switch (input) {
+function formatOutcome(test) {
+    if (test.timedOut === true) {
+        return 'Timeout';
+    }
+    if (test.pending === true) {
+        return 'Pending';
+    }
+    switch (test.state) {
         case 'passed':
         case 'failed':
-            output = input.charAt(0).toUpperCase() + input.slice(1);
-            break;
+            return test.state.charAt(0).toUpperCase() + test.state.slice(1);
         default:
-            output = 'Inconclusive';
+            return 'Inconclusive';
     }
-    return output;
 }

--- a/lib/trx.js
+++ b/lib/trx.js
@@ -33,7 +33,7 @@ function ReporterTrx(runner, options) {
     runner.on('end', function () {
         var obj = {
             stats: self.stats,
-            tests: tests.map(mask)
+            tests: tests
         };
 
         runner.testResults = obj;
@@ -66,25 +66,6 @@ function ReporterTrx(runner, options) {
             process.stdout.write(run.toXml());
         }
     });
-}
-
-/**
- * Masks mocha test object
- *
- * @param test
- * @returns {Object}
- */
-function mask(test) {
-    return {
-        // remove smoke tag and test case number
-        title: test.title.replace(' @smoke', '').replace(/ \[C\d+\]/, ''),
-        fullTitle: test.fullTitle().replace(' @smoke', '').replace(/ \[C\d+\]/, ''),
-        duration: test.duration || 0,
-        err: test.err,
-        state: test.state,
-        start: test.start,
-        end: test.end
-    }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mocha-trx-reporter",
   "description": "A mocha reporter for trx",
   "version": "2.0.1",
-  "author": "Pablo Penén <ppenen@infragistics.com>",
+  "author": "Pablo PenÃ©n <ppenen@infragistics.com>",
   "license": "MIT",
   "repository": "Infragistics/mocha-trx-reporter",
   "homepage": "https://github.com/Infragistics/mocha-trx-reporter",
@@ -13,11 +13,11 @@
   ],
   "main": "lib/trx.js",
   "dependencies": {
-    "mocha": "^2.4.5",
-    "node-trx": "git://github.com/indigostudio/node-trx.git#master"
+    "mocha": "~3.0.1",
+    "node-trx": "git://github.com/bgever/node-trx.git#support-pending-and-timeout-outcomes"
   },
   "devDependencies": {
-    "should": "^7.0.3"
+    "should": "^10.0.0"
   },
   "scripts": {
     "test": "mocha test/",

--- a/test/test-to-trx.test.js
+++ b/test/test-to-trx.test.js
@@ -8,9 +8,10 @@ describe('On test-to-trx', function () {
     it('should generate correct trx object for passed test', function () {
         var mochaTestMock = {
             title: '1 should be 1',
-            fullTitle: 'On sample test 1 should be 1',
+            fullTitle: function() { return 'On sample test 1 should be 1'; },
             duration: 1243,
             err: undefined,
+            pending: false,
             state: 'passed',
             start: new Date('2015-08-10T00:00:00.000Z'),
             end: new Date('2015-08-10T00:00:01.234Z')
@@ -42,8 +43,9 @@ describe('On test-to-trx', function () {
     it('should generate correct trx object for failed test', function () {
         var mochaTestMock = {
             title: '1 should be 3',
-            fullTitle: 'On sample test 1 should be 3',
+            fullTitle: function() { return 'On sample test 1 should be 3'; },
             duration: 10000,
+            pending: false,
             state: 'failed',
             start: new Date('2015-08-10T00:00:00.000Z'),
             end: new Date('2015-08-10T00:00:10.000Z'),
@@ -69,12 +71,70 @@ describe('On test-to-trx', function () {
         trxTest.test.should.be.instanceOf(Object);
     });
 
-    it('should generate correct trx object for skipped test', function () {
+    it('should generate correct trx object for timed out test', function () {
         var mochaTestMock = {
             title: '1 should be 2',
-            fullTitle: 'On sample test 1 should be 2',
+            fullTitle: function() { return 'On sample test 1 should be 2'; },
             duration: 0,
             err: undefined,
+            timedOut: true,
+            pending: false,
+            state: undefined,
+            start: new Date('2015-08-10T00:00:00.000Z'),
+            end: undefined
+        };
+
+        var trxTest = testToTrx(mochaTestMock, computerName);
+
+        trxTest.should.be.instanceOf(Object);
+        trxTest.should.have.property('computerName', 'mycomputer');
+        trxTest.should.have.property('outcome', 'Timeout');
+        trxTest.should.have.property('duration', '00:00:00.000');
+        trxTest.should.have.property('startTime', '2015-08-10T00:00:00.000Z');
+        trxTest.should.have.property('endTime', '');
+        trxTest.should.have.property('errorMessage', '');
+        trxTest.should.have.property('errorStacktrace', '');
+
+
+        trxTest.should.have.property('test');
+        trxTest.test.should.be.instanceOf(Object);
+    });
+
+    it('should generate correct trx object for pending (skipped) test', function () {
+        var mochaTestMock = {
+            title: '1 should be 2',
+            fullTitle: function() { return 'On sample test 1 should be 2'; },
+            duration: 0,
+            err: undefined,
+            pending: true,
+            state: undefined,
+            start: new Date('2015-08-10T00:00:00.000Z'),
+            end: undefined
+        };
+
+        var trxTest = testToTrx(mochaTestMock, computerName);
+
+        trxTest.should.be.instanceOf(Object);
+        trxTest.should.have.property('computerName', 'mycomputer');
+        trxTest.should.have.property('outcome', 'Pending');
+        trxTest.should.have.property('duration', '00:00:00.000');
+        trxTest.should.have.property('startTime', '2015-08-10T00:00:00.000Z');
+        trxTest.should.have.property('endTime', '');
+        trxTest.should.have.property('errorMessage', '');
+        trxTest.should.have.property('errorStacktrace', '');
+
+
+        trxTest.should.have.property('test');
+        trxTest.test.should.be.instanceOf(Object);
+    });
+
+    it('should generate correct trx object for unknown test result', function () {
+        var mochaTestMock = {
+            title: '1 should be 2',
+            fullTitle: function() { return 'On sample test 1 should be 2'; },
+            duration: 0,
+            err: undefined,
+            pending: false,
             state: undefined,
             start: new Date('2015-08-10T00:00:00.000Z'),
             end: undefined
@@ -95,5 +155,4 @@ describe('On test-to-trx', function () {
         trxTest.should.have.property('test');
         trxTest.test.should.be.instanceOf(Object);
     });
-
 });

--- a/test/trx.test.js
+++ b/test/trx.test.js
@@ -14,31 +14,33 @@ describe('On trx reporter', function(){
             reporter: trxReporter
         });
         suite = new Suite('TRX suite', 'root');
+        suite.timeout(100);
         runner = new Runner(suite);
         var mochaReporter = new mocha._reporter(runner);
 
-        var testTitle = 'trx test';
-        var error = { message: 'omg' };
-
-        suite.addTest(new Test(testTitle, function (done) {
-            done(new Error(error.message));
+        suite.addTest(new Test('handles errors', function (done) {
+            done(new Error({ message: 'omg' }));
         }));
 
-        suite.addTest(new Test(testTitle));
+        suite.addTest(new Test('handles pending tests'));
 
-        suite.addTest(new Test(testTitle, function (done) {
+        suite.addTest(new Test('handles async tests', function (done) {
             done();
+        }));
+
+        suite.addTest(new Test('handles timeout', function (done) {
+            setTimeout(done, 200);
         }));
     });
 
-    it('should create correct mocha test result', function(done){
+    it('should create correct mocha test result', function (done) {
 
         runner.run(function(failureCount) {
-            failureCount.should.be.exactly(1);
+            failureCount.should.be.exactly(2);
             runner.should.have.property('testResults');
             runner.testResults.should.have.property('tests');
             runner.testResults.tests.should.be.an.instanceOf(Array);
-            runner.testResults.tests.should.have.a.lengthOf(3);
+            runner.testResults.tests.should.have.a.lengthOf(4);
 
             done();
         });


### PR DESCRIPTION
This PR adds support for pending (without a function body--pending implementation, or marked with `.skip`) and timed out tests. These map to the Pending and Timeout TRX outcomes.

The current node-trx version doesn't support these outcomes, but pending PR bmancini55/node-trx#3 adds this support. This PR has a dependency on the fork backing the node-trx PR. This can be updated to an official release, when it's accepted by @bmancini55.

---

Into detail, the `mask()` function would mask away the `pending` and `timedOut` states of the test result. Therefore I've changed the code to pass-through the Test class as-is, and adapt the code to handle this change. I couldn't see the "smoke tag" as mentioned in the comment which seems to be the main purpose of this mask? The unit tests run correctly and the output also looks as expected without the mask.

I've also updated the module dependencies to match the latest versions, with patch version dependencies to prevent including potential breaking version changes in future. As said, I hope the node-trx dependency could be updated to an official `~0.5.0` dependency soon.

@santiagoaguiar, hope you have some time to review this PR, as the current version is reporting an incorrect test result percentage in [Visual Studio Team Services](https://www.visualstudio.com/en-us/docs/test/continuous-testing/continuous-testing).

Thanks gents!