### PR TITLE
Pending as NotExecuted outcome option

### DIFF
--- a/lib/test-to-trx.js
+++ b/lib/test-to-trx.js
@@ -13,15 +13,15 @@ module.exports = testToTrx;
 function testToTrx(test, computerName) {
     return {
         test: new UnitTest({
-            name: test.fullTitle,
+            name: test.fullTitle(),
             methodName: '', //??
             methodCodeBase: '', //??
             methodClassName: '', //??
             description: test.title
         }),
         computerName: computerName,
-        outcome: formatOutcome(test.state),
-        duration: formatDuration(test.duration),
+        outcome: formatOutcome(test),
+        duration: formatDuration(test.duration || 0),
         startTime: test.start && test.start.toISOString() || '', //'2010-11-16T08:48:29.9072393-08:00',
         endTime: test.end && test.end.toISOString() || '', //'2010-11-16T08:49:16.9694381-08:00'
         errorMessage: test.err && test.err._message || '',
@@ -47,26 +47,33 @@ function formatDuration(milliseconds) {
 }
 
 /**
- * Transform mocha test state to trx outcome
+ * Transform mocha test result to trx outcome.
  *
- * input     | output
- * ---------------------
+ * Tests may have timed out, resulting in outcome 'Timeout'.
+ * Tests may be pending as indicated by the test itself or their parent suite, resulting in outcome 'Pending'.
+ * When not pending, the Mocha test state is converted as follows:
+ *
+ * State     | TRX outcome
+ * --------------------------
  * 'passed'  | 'Passed'
  * 'failed'  | 'Failed'
  * undefined | 'Inconclusive'
  *
- * @param input
+ * @param test
  * @returns {string}
  */
-function formatOutcome(input) {
-    var output;
-    switch (input) {
+function formatOutcome(test) {
+    if (test.timedOut === true) {
+        return 'Timeout';
+    }
+    if (test.pending === true) {
+        return 'Pending';
+    }
+    switch (test.state) {
         case 'passed':
         case 'failed':
-            output = input.charAt(0).toUpperCase() + input.slice(1);
-            break;
+            return test.state.charAt(0).toUpperCase() + test.state.slice(1);
         default:
-            output = 'Inconclusive';
+            return 'Inconclusive';
     }
-    return output;
 }

--- a/lib/test-to-trx.js
+++ b/lib/test-to-trx.js
@@ -8,9 +8,10 @@ module.exports = testToTrx;
  *
  * @param test
  * @param computerName
+ * @param options The reporter options.
  * @returns {Object}
  */
-function testToTrx(test, computerName) {
+function testToTrx(test, computerName, options) {
     return {
         test: new UnitTest({
             name: test.fullTitle(),
@@ -20,7 +21,7 @@ function testToTrx(test, computerName) {
             description: test.title
         }),
         computerName: computerName,
-        outcome: formatOutcome(test),
+        outcome: formatOutcome(test, options),
         duration: formatDuration(test.duration || 0),
         startTime: test.start && test.start.toISOString() || '', //'2010-11-16T08:48:29.9072393-08:00',
         endTime: test.end && test.end.toISOString() || '', //'2010-11-16T08:49:16.9694381-08:00'
@@ -51,6 +52,7 @@ function formatDuration(milliseconds) {
  *
  * Tests may have timed out, resulting in outcome 'Timeout'.
  * Tests may be pending as indicated by the test itself or their parent suite, resulting in outcome 'Pending'.
+ * Unless, when the option `treatPendingAsNotExecuted` is true, the outcome is 'NotExecuted' instead of 'Pending'.
  * When not pending, the Mocha test state is converted as follows:
  *
  * State     | TRX outcome
@@ -60,14 +62,16 @@ function formatDuration(milliseconds) {
  * undefined | 'Inconclusive'
  *
  * @param test
+ * @param options Reporter options, including treatPendingAsNotExecuted.
  * @returns {string}
  */
-function formatOutcome(test) {
+function formatOutcome(test, options) {
+    options = options || {};
     if (test.timedOut === true) {
         return 'Timeout';
     }
     if (test.pending === true) {
-        return 'Pending';
+        return options.treatPendingAsNotExecuted === true ? 'NotExecuted' : 'Pending';
     }
     switch (test.state) {
         case 'passed':

--- a/lib/trx.js
+++ b/lib/trx.js
@@ -33,7 +33,7 @@ function ReporterTrx(runner, options) {
     runner.on('end', function () {
         var obj = {
             stats: self.stats,
-            tests: tests.map(mask)
+            tests: tests
         };
 
         runner.testResults = obj;
@@ -66,25 +66,6 @@ function ReporterTrx(runner, options) {
             process.stdout.write(run.toXml());
         }
     });
-}
-
-/**
- * Masks mocha test object
- *
- * @param test
- * @returns {Object}
- */
-function mask(test) {
-    return {
-        // remove smoke tag and test case number
-        title: test.title.replace(' @smoke', '').replace(/ \[C\d+\]/, ''),
-        fullTitle: test.fullTitle().replace(' @smoke', '').replace(/ \[C\d+\]/, ''),
-        duration: test.duration || 0,
-        err: test.err,
-        state: test.state,
-        start: test.start,
-        end: test.end
-    }
 }
 
 /**

--- a/lib/trx.js
+++ b/lib/trx.js
@@ -56,7 +56,7 @@ function ReporterTrx(runner, options) {
         });
 
         runner.testResults.tests.forEach(function (test) {
-            run.addResult(testToTrx(test, computerName));
+            run.addResult(testToTrx(test, computerName, options.reporterOptions));
         });
 
         var filename = getFilename(self.reporterOptions);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mocha-trx-reporter",
   "description": "A mocha reporter for trx",
   "version": "2.0.1",
-  "author": "Pablo Penén <ppenen@infragistics.com>",
+  "author": "Pablo PenÃ©n <ppenen@infragistics.com>",
   "license": "MIT",
   "repository": "Infragistics/mocha-trx-reporter",
   "homepage": "https://github.com/Infragistics/mocha-trx-reporter",
@@ -13,11 +13,11 @@
   ],
   "main": "lib/trx.js",
   "dependencies": {
-    "mocha": "^2.4.5",
-    "node-trx": "git://github.com/indigostudio/node-trx.git#master"
+    "mocha": "~3.0.1",
+    "node-trx": "git://github.com/bgever/node-trx.git#support-pending-and-timeout-outcomes"
   },
   "devDependencies": {
-    "should": "^7.0.3"
+    "should": "^10.0.0"
   },
   "scripts": {
     "test": "mocha test/",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "lib/trx.js",
   "dependencies": {
     "mocha": "~3.0.1",
-    "node-trx": "git://github.com/bgever/node-trx.git#support-pending-and-timeout-outcomes"
+    "node-trx": "git://github.com/bgever/node-trx.git#support-notexecuted-outcome"
   },
   "devDependencies": {
     "should": "^10.0.0"

--- a/test/test-to-trx.test.js
+++ b/test/test-to-trx.test.js
@@ -8,9 +8,10 @@ describe('On test-to-trx', function () {
     it('should generate correct trx object for passed test', function () {
         var mochaTestMock = {
             title: '1 should be 1',
-            fullTitle: 'On sample test 1 should be 1',
+            fullTitle: function() { return 'On sample test 1 should be 1'; },
             duration: 1243,
             err: undefined,
+            pending: false,
             state: 'passed',
             start: new Date('2015-08-10T00:00:00.000Z'),
             end: new Date('2015-08-10T00:00:01.234Z')
@@ -42,8 +43,9 @@ describe('On test-to-trx', function () {
     it('should generate correct trx object for failed test', function () {
         var mochaTestMock = {
             title: '1 should be 3',
-            fullTitle: 'On sample test 1 should be 3',
+            fullTitle: function() { return 'On sample test 1 should be 3'; },
             duration: 10000,
+            pending: false,
             state: 'failed',
             start: new Date('2015-08-10T00:00:00.000Z'),
             end: new Date('2015-08-10T00:00:10.000Z'),
@@ -69,12 +71,70 @@ describe('On test-to-trx', function () {
         trxTest.test.should.be.instanceOf(Object);
     });
 
-    it('should generate correct trx object for skipped test', function () {
+    it('should generate correct trx object for timed out test', function () {
         var mochaTestMock = {
             title: '1 should be 2',
-            fullTitle: 'On sample test 1 should be 2',
+            fullTitle: function() { return 'On sample test 1 should be 2'; },
             duration: 0,
             err: undefined,
+            timedOut: true,
+            pending: false,
+            state: undefined,
+            start: new Date('2015-08-10T00:00:00.000Z'),
+            end: undefined
+        };
+
+        var trxTest = testToTrx(mochaTestMock, computerName);
+
+        trxTest.should.be.instanceOf(Object);
+        trxTest.should.have.property('computerName', 'mycomputer');
+        trxTest.should.have.property('outcome', 'Timeout');
+        trxTest.should.have.property('duration', '00:00:00.000');
+        trxTest.should.have.property('startTime', '2015-08-10T00:00:00.000Z');
+        trxTest.should.have.property('endTime', '');
+        trxTest.should.have.property('errorMessage', '');
+        trxTest.should.have.property('errorStacktrace', '');
+
+
+        trxTest.should.have.property('test');
+        trxTest.test.should.be.instanceOf(Object);
+    });
+
+    it('should generate correct trx object for pending (skipped) test', function () {
+        var mochaTestMock = {
+            title: '1 should be 2',
+            fullTitle: function() { return 'On sample test 1 should be 2'; },
+            duration: 0,
+            err: undefined,
+            pending: true,
+            state: undefined,
+            start: new Date('2015-08-10T00:00:00.000Z'),
+            end: undefined
+        };
+
+        var trxTest = testToTrx(mochaTestMock, computerName);
+
+        trxTest.should.be.instanceOf(Object);
+        trxTest.should.have.property('computerName', 'mycomputer');
+        trxTest.should.have.property('outcome', 'Pending');
+        trxTest.should.have.property('duration', '00:00:00.000');
+        trxTest.should.have.property('startTime', '2015-08-10T00:00:00.000Z');
+        trxTest.should.have.property('endTime', '');
+        trxTest.should.have.property('errorMessage', '');
+        trxTest.should.have.property('errorStacktrace', '');
+
+
+        trxTest.should.have.property('test');
+        trxTest.test.should.be.instanceOf(Object);
+    });
+
+    it('should generate correct trx object for unknown test result', function () {
+        var mochaTestMock = {
+            title: '1 should be 2',
+            fullTitle: function() { return 'On sample test 1 should be 2'; },
+            duration: 0,
+            err: undefined,
+            pending: false,
             state: undefined,
             start: new Date('2015-08-10T00:00:00.000Z'),
             end: undefined
@@ -95,5 +155,4 @@ describe('On test-to-trx', function () {
         trxTest.should.have.property('test');
         trxTest.test.should.be.instanceOf(Object);
     });
-
 });

--- a/test/test-to-trx.test.js
+++ b/test/test-to-trx.test.js
@@ -1,7 +1,7 @@
 var should = require('should');
 var testToTrx = require('../lib/test-to-trx');
 
-describe('On test-to-trx', function () {
+describe('Module test-to-trx', function () {
 
     var computerName = 'mycomputer';
 

--- a/test/trx.test.js
+++ b/test/trx.test.js
@@ -14,31 +14,33 @@ describe('On trx reporter', function(){
             reporter: trxReporter
         });
         suite = new Suite('TRX suite', 'root');
+        suite.timeout(100);
         runner = new Runner(suite);
         var mochaReporter = new mocha._reporter(runner);
 
-        var testTitle = 'trx test';
-        var error = { message: 'omg' };
-
-        suite.addTest(new Test(testTitle, function (done) {
-            done(new Error(error.message));
+        suite.addTest(new Test('handles errors', function (done) {
+            done(new Error({ message: 'omg' }));
         }));
 
-        suite.addTest(new Test(testTitle));
+        suite.addTest(new Test('handles pending tests'));
 
-        suite.addTest(new Test(testTitle, function (done) {
+        suite.addTest(new Test('handles async tests', function (done) {
             done();
+        }));
+
+        suite.addTest(new Test('handles timeout', function (done) {
+            setTimeout(done, 200);
         }));
     });
 
-    it('should create correct mocha test result', function(done){
+    it('should create correct mocha test result', function (done) {
 
         runner.run(function(failureCount) {
-            failureCount.should.be.exactly(1);
+            failureCount.should.be.exactly(2);
             runner.should.have.property('testResults');
             runner.testResults.should.have.property('tests');
             runner.testResults.tests.should.be.an.instanceOf(Array);
-            runner.testResults.tests.should.have.a.lengthOf(3);
+            runner.testResults.tests.should.have.a.lengthOf(4);
 
             done();
         });

--- a/test/trx.test.js
+++ b/test/trx.test.js
@@ -6,44 +6,81 @@ var Suite = Mocha.Suite,
 var trxReporter = require('../lib/trx.js');
 var should = require('should');
 
-describe('On trx reporter', function(){
-    var suite, runner;
+describe('Mocha with mocha-trx-reporter', function () {
 
-    beforeEach(function(){
-        var mocha = new Mocha({
-            reporter: trxReporter
+    context('having default options', function () {
+
+        var mocha;
+
+        beforeEach(function () {
+            mocha = new Mocha({
+                reporter: trxReporter,
+                timeout: 100
+            });
+            var suite = new Suite('TRX suite', 'root');
+            suite.addTest(new Test('handles errors', function (done) {
+                done(new Error({ message: 'omg' }));
+            }));
+            suite.addTest(new Test('handles pending tests'));
+            suite.addTest(new Test('handles async tests', function (done) {
+                done();
+            }));
+            suite.addTest(new Test('handles timeout', function (done) {
+                setTimeout(done, 200);
+            }));
+            mocha.suite = suite;
         });
-        suite = new Suite('TRX suite', 'root');
-        suite.timeout(100);
-        runner = new Runner(suite);
-        var mochaReporter = new mocha._reporter(runner);
 
-        suite.addTest(new Test('handles errors', function (done) {
-            done(new Error({ message: 'omg' }));
-        }));
+        describe('run', function () {
 
-        suite.addTest(new Test('handles pending tests'));
+            it('should create correct test result', function (done) {
 
-        suite.addTest(new Test('handles async tests', function (done) {
-            done();
-        }));
-
-        suite.addTest(new Test('handles timeout', function (done) {
-            setTimeout(done, 200);
-        }));
+                var runner = mocha.run();
+                runner.on('end', function () {
+                    runner.failures.should.be.exactly(1);
+                    runner.should.have.property('testResults');
+                    runner.testResults.should.have.property('tests');
+                    runner.testResults.tests.should.be.an.instanceOf(Array);
+                    runner.testResults.tests.should.have.a.lengthOf(4);
+                    done();
+                });
+            });
+        });
     });
 
-    it('should create correct mocha test result', function (done) {
+    context('having custom options', function () {
 
-        runner.run(function(failureCount) {
-            failureCount.should.be.exactly(2);
-            runner.should.have.property('testResults');
-            runner.testResults.should.have.property('tests');
-            runner.testResults.tests.should.be.an.instanceOf(Array);
-            runner.testResults.tests.should.have.a.lengthOf(4);
+        context('treatPendingAsNotExecuted enabled', function () {
 
-            done();
+            var mocha;
+
+            beforeEach(function () {
+                mocha = new Mocha({
+                    reporter: trxReporter,
+                    reporterOptions: {
+                        treatPendingAsNotExecuted: true
+                    }
+                });
+                var suite = new Suite('TRX suite', 'root');
+                suite.addTest(new Test('handles pending tests'));
+                mocha.suite = suite;
+            });
+
+            describe('run', function () {
+
+                it('should create correct mocha test result', function (done) {
+
+                    var runner = mocha.run();
+                    runner.on('end', function () {
+                        runner.failures.should.be.exactly(0);
+                        runner.should.have.property('testResults');
+                        runner.testResults.should.have.property('tests');
+                        runner.testResults.tests.should.be.an.instanceOf(Array);
+                        runner.testResults.tests.should.have.a.lengthOf(1);
+                        done();
+                    })
+                });
+            });
         });
     });
-
 });


### PR DESCRIPTION
This PR extends on PR #4 by adding a reporter option `treatPendingAsNotExecuted` (by default turned off) to toggle whether Pending outcomes should be reported as NotExecuted instead.

Some systems like VSTS Tests do not support the Pending state currently, and this option can be used as a workaround. See Microsoft/vsts-tasks#2234.

To get correct NotExecuted counts in the ResultSummary section of the TRX, this PR depends on the eventual update of the node-trx dependency per PR bmancini55/node-trx#4 (v0.6).

The PR also improves the way how tests are called by setting up and calling results through the main Mocha instance, to improve support for mocha options.