### PR TITLE
Secondary reporter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ or you can set `MOCHA_REPORTER_FILE` environment var with the desired filename
 - **warnExcludedPending** (boolean)  
   When combined with *excludePending*, writes a warning to stderr with the number of
   tests that have been excluded because they had the state `Pending`, if the number is more than 0.
+- **secondary** (string)  
+  Name of the built-in or node module reporter, to be executed when *output* has been specified. It acts as a secondary
+  reporter in addition to the TRX reporter. Without a secondary reporter and an *output* file specified, the output to
+  stdout would be empty.
+- **secondary_{secondary-reporter-option}** (string/boolean)  
+  Any option starting with "secondary_" will be passed down to the secondary reporter without the prefix.
 
 ## Development
 

--- a/lib/trx.js
+++ b/lib/trx.js
@@ -1,4 +1,5 @@
-var Base = require('mocha').reporters.Base,
+var reporters = require('mocha').reporters,
+    Base = reporters.Base,
     TRX = require('node-trx'),
     TestRun = TRX.TestRun,
     os = require('os'),
@@ -20,6 +21,8 @@ function ReporterTrx(runner, options) {
 
     var self = this;
     var tests = [];
+    var reporterOptions = options.reporterOptions || {};
+    var outputFile = reporterOptions.output || process.env.MOCHA_REPORTER_FILE;
 
     runner.on('test', function (test) {
         test.start = new Date();
@@ -55,7 +58,6 @@ function ReporterTrx(runner, options) {
             }
         });
 
-        var reporterOptions = options.reporterOptions || {};
         var excludedPendingCount = 0;
 
         runner.testResults.tests.forEach(function (test) {
@@ -73,27 +75,41 @@ function ReporterTrx(runner, options) {
                     : 'Excluded ' + excludedPendingCount + ' tests because they are marked as Pending.'));
         }
 
-        var filename = getFilename(self.reporterOptions);
-        if (filename) {
-            require('fs').writeFileSync(filename, run.toXml());
+        if (outputFile) {
+            require('fs').writeFileSync(outputFile, run.toXml());
         } else {
             process.stdout.write(run.toXml());
         }
     });
+
+    if (outputFile && reporterOptions.secondary) {
+        var secondaryReporter = reporters[reporterOptions.secondary];
+        // Try to load reporters from process.cwd() and node_modules
+        if (!secondaryReporter) {
+            try {
+                secondaryReporter = require(reporterOptions.secondary);
+            } catch (err) {
+                err.message.indexOf('Cannot find module') !== -1
+                    ? console.warn('"' + reporterOptions.secondary + '" reporter not found')
+                    : console.warn('"' + reporterOptions.secondary + '" reporter blew up with error:\n' + err.stack);
+            }
+        }
+        if (!secondaryReporter) {
+            throw new Error('invalid reporter "' + reporterOptions.secondary + '"');
+        }
+        var secondaryReporterOptions = {};
+        for (option in reporterOptions) {
+            if (option.indexOf('secondary_') === 0) {
+                secondaryReporterOptions[option.substring(10)] = reporterOptions[option];
+            }
+        }
+        this.secondaryReporterInstance = new secondaryReporter(runner, secondaryReporterOptions);
+    }
 }
 
-/**
- * Gets filename from:
- *
- * - reporter options (as given by mocha's --reporter-options output=>filename>
- * or
- * - env var: MOCHA_REPORTER_FILE
- *
- * prioritizing process arg variable
- *
- * @returns {boolean|*}
- */
-function getFilename(reporterOptions) {
-    return (reporterOptions ? reporterOptions.output : null)
-        || process.env.MOCHA_REPORTER_FILE;
+ReporterTrx.prototype.done = function (failures, fn) {
+    if (this.secondaryReporterInstance && this.secondaryReporterInstance.done) {
+        this.secondaryReporterInstance.done(failures);
+    }
+    fn && fn(failures);
 }

--- a/test/secondary-reporter.js
+++ b/test/secondary-reporter.js
@@ -1,0 +1,29 @@
+/**
+ * Module dependencies.
+ */
+
+var Base = require('mocha').reporters.Base;
+
+/**
+ * Expose `Secondary`.
+ */
+
+exports = module.exports = Secondary;
+
+/**
+ * Initialize a new `Secondary` test reporter.
+ *
+ * @api public
+ * @param {Runner} runner
+ * @param options
+ */
+function Secondary(runner, options) {
+    Base.call(this, runner, options);
+
+    console.log('Secondary options:');
+    console.log(options);
+}
+
+Secondary.prototype.done = function (failures) {
+    console.log('Secondary done with ' + failures + ' failures.')
+}

--- a/test/trx.test.js
+++ b/test/trx.test.js
@@ -154,5 +154,82 @@ describe('Mocha with mocha-trx-reporter', function () {
                 });
             });
         });
+
+        context('output file and secondary set to spec', function () {
+
+            var mocha;
+
+            beforeEach(function () {
+                mocha = new Mocha({
+                    reporter: trxReporter,
+                    reporterOptions: {
+                        output: 'test/trx.test.output.trx',
+                        secondary: 'spec'
+                    }
+                });
+                var suite = new Suite('TRX suite', 'root');
+                firstSuite = new Suite('first suite');
+                firstSuite.addTest(new Test('handles pass', function(done){
+                    done();
+                }));
+                firstSuite.addTest(new Test('handles fail', function(done){
+                    done(new Error('oops'));
+                }));
+                suite.addSuite(firstSuite);
+                suite.addTest(new Test('handles pending'));
+                mocha.suite = suite;
+            });
+
+            describe('run', function () {
+
+                it('outputs mocha spec to stdout and trx to file', function (done) {
+
+                    var runner = mocha.run();
+                    runner.on('end', function () {
+                        runner.failures.should.be.exactly(1);
+                        runner.should.have.property('testResults');
+                        runner.testResults.should.have.property('tests');
+                        runner.testResults.tests.should.be.an.instanceOf(Array);
+                        runner.testResults.tests.should.have.a.lengthOf(3);
+                        done();
+                    })
+                });
+            });
+        });
+
+        context('output file and secondary set to Secondary with options', function () {
+
+            var mocha;
+
+            beforeEach(function () {
+                mocha = new Mocha({
+                    reporter: trxReporter,
+                    reporterOptions: {
+                        output: 'test/trx.test.output.trx',
+                        secondary: './../test/secondary-reporter',
+                        secondary_option: 'value'
+                    }
+                });
+                var suite = new Suite('TRX suite', 'root');
+                suite.addTest(new Test('handles pending'));
+                mocha.suite = suite;
+            });
+
+            describe('run', function () {
+
+                it('outputs mocha Secondary reporter to stdout and trx to file', function (done) {
+
+                    var runner = mocha.run();
+                    runner.on('end', function () {
+                        runner.failures.should.be.exactly(0);
+                        runner.should.have.property('testResults');
+                        runner.testResults.should.have.property('tests');
+                        runner.testResults.tests.should.be.an.instanceOf(Array);
+                        runner.testResults.tests.should.have.a.lengthOf(1);
+                        done();
+                    })
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
_Note, this PR builds on top of #4, #5 & #6. Review those first before accepting this one._

This PR adds support for an option `secondary` which works the same as Mocha's `reporter` option. It loads the specified reporter after the TRX reporter is initialized, but only when an `output` option has been set.

This allows to provide a human readable output, in addition to the TRX file creation. Especially useful for long running tests, as you are otherwise staring at blank output on the CLI.

The `secondary` option accepts any built-in reporter like `spec` or `dot`, but can also load node modules, in the same way that is done in the Mocha codebase. There is a unit test that covers this scenario.

Some reporters have their own options. Since the CLI only support a single parameter to pass in reporter options, the secondary options need to be mixed with the TRX options. To avoid conflicts, the ones for the secondary reporter are prefixed with "secondary_". This prefix is used to find all options for the secondary reporter, and the prefix is removed when those options are passed down to the secondary reporter.
