### PR TITLE
Fix to conform with tfs 2013 format

### DIFF
--- a/lib/test-to-trx.js
+++ b/lib/test-to-trx.js
@@ -37,10 +37,11 @@ module.exports = testToTrx;
  * @returns {Object}
  */
 function testToTrx(test, computerName, cwd, options) {
+    var safeCwd = cwd || "";
     return {
         test: new UnitTest({
             name: test.fullTitle(),
-            methodCodeBase: path.relative(cwd, test.file),
+            methodCodeBase: test.file ? path.relative(safeCwd, test.file) : "none",
             methodName: "none",
             methodClassName: "none"
         }),

--- a/lib/test-to-trx.js
+++ b/lib/test-to-trx.js
@@ -1,7 +1,32 @@
 var TRX = require('node-trx'),
     UnitTest = TRX.UnitTest;
+var path = require('path');
 
 module.exports = testToTrx;
+
+/*  What follows are useful properties for types Test, Runnable and Suite
+ *
+ *  Test : Runnable {
+ *      title: string
+ *      file: string
+ *      parent: suite
+ *  }
+ *
+ *  Runnable {
+ *      body: string
+ *      timedOut: boolean
+ *      isPending(): boolean
+ *      currentRetry(): number
+ *      fullTitle(): string
+ *  }
+ *
+ *  Suite {
+ *      title: string
+ *      fullTitle(): string
+ *      parent: suite
+ *      root: boolean
+ *  }
+ */
 
 /**
  * Transform mocha test to trx obj
@@ -11,14 +36,13 @@ module.exports = testToTrx;
  * @param options The reporter options.
  * @returns {Object}
  */
-function testToTrx(test, computerName, options) {
+function testToTrx(test, computerName, cwd, options) {
     return {
         test: new UnitTest({
             name: test.fullTitle(),
-            methodName: '', //??
-            methodCodeBase: '', //??
-            methodClassName: '', //??
-            description: test.title
+            methodCodeBase: path.relative(cwd, test.file),
+            methodName: "none",
+            methodClassName: "none"
         }),
         computerName: computerName,
         outcome: formatOutcome(test, options),

--- a/lib/trx.js
+++ b/lib/trx.js
@@ -3,7 +3,7 @@ var Base = require('mocha').reporters.Base,
     TestRun = TRX.TestRun,
     os = require('os'),
     computerName = os.hostname(),
-    userName = process.env.USER;
+    userName = os.userInfo().username;
 
 var testToTrx = require('./test-to-trx');
 
@@ -20,6 +20,7 @@ function ReporterTrx(runner, options) {
 
     var self = this;
     var tests = [];
+    var cwd = process.cwd();
 
     runner.on('test', function (test) {
         test.start = new Date();
@@ -63,7 +64,7 @@ function ReporterTrx(runner, options) {
                 excludedPendingCount++;
                 return;
             }
-            run.addResult(testToTrx(test, computerName, reporterOptions));
+            run.addResult(testToTrx(test, computerName, cwd, reporterOptions));
         });
 
         if (reporterOptions.warnExcludedPending === true && excludedPendingCount > 0) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mocha-trx-reporter",
   "description": "A mocha reporter for trx",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Pablo Penén <ppenen@infragistics.com>",
   "license": "MIT",
   "repository": "Infragistics/mocha-trx-reporter",

--- a/test/test-to-trx.test.js
+++ b/test/test-to-trx.test.js
@@ -9,6 +9,7 @@ describe('Module test-to-trx', function () {
         var mochaTestMock = {
             title: '1 should be 1',
             fullTitle: function() { return 'On sample test 1 should be 1'; },
+            file: "testfile.js",
             duration: 1243,
             err: undefined,
             pending: false,
@@ -17,7 +18,7 @@ describe('Module test-to-trx', function () {
             end: new Date('2015-08-10T00:00:01.234Z')
         };
 
-        var trxTest = testToTrx(mochaTestMock, computerName);
+        var trxTest = testToTrx(mochaTestMock, computerName, process.cwd());
 
         trxTest.should.be.instanceOf(Object);
         trxTest.should.have.property('computerName', 'mycomputer');
@@ -34,10 +35,9 @@ describe('Module test-to-trx', function () {
         trxTest.test.should.have.property('id');
         trxTest.test.should.have.property('name', 'On sample test 1 should be 1');
         trxTest.test.should.have.property('type');
-        trxTest.test.should.have.property('methodName', '');
-        trxTest.test.should.have.property('methodCodeBase', '');
-        trxTest.test.should.have.property('methodClassName', '');
-        trxTest.test.should.have.property('description', '1 should be 1');
+        trxTest.test.should.have.property('methodName', 'none');
+        trxTest.test.should.have.property('methodCodeBase', 'testfile.js');
+        trxTest.test.should.have.property('methodClassName', 'none');
     });
 
     it('should generate correct trx object for failed test', function () {


### PR DESCRIPTION
TFS 2013 accepts the trx report but when you need to open it from Visual Studio (connected to TFS), the trx is invalid.

This is due to having blank attributes in `<TestMethod>` element. This fix populates those attributes.
It also removes the `<Description>` as it isn't mandatory and has the same information as the `name` attribute.